### PR TITLE
fix: incorrect call to server method which caused autocomplete to break

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -79,7 +79,7 @@ export class TwindPlugin {
       ...languageService,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      getCompletionEntryDetails: (fileName, position, name, ...rest: any[]) => {
+      getCompletionEntryDetails: (fileName, position, name, ...rest) => {
         if (enable && ttls.enabled) {
           const context = helper.getTemplate(fileName, position)
 
@@ -92,8 +92,7 @@ export class TwindPlugin {
           }
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (languageService.getCompletionsAtPosition as any)(fileName, position, name, ...rest)
+        return languageService.getCompletionEntryDetails(fileName, position, name, ...rest)
       },
 
       getCompletionsAtPosition: (fileName, position, options) => {


### PR DESCRIPTION
The wrong method was called here. I don't think this was intentional since the latter part is the "no-twind-specific" one. 

I believe this Resolves https://github.com/tw-in-js/vscode-twind-intellisense/issues/2 according to my testing. And also resolves https://github.com/tw-in-js/typescript-plugin/issues/18