### PR TITLE
fix: support Typescript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "match-sorter": "^6.3.0",
     "sucrase": "^3.17.1",
     "twind": "^0.16.10",
-    "typescript": "^4.1.0",
+    "typescript": "^5.5.3",
     "typescript-template-language-service-decorator": "^2.2.0",
     "vscode-languageserver-types": "^3.13.0"
   },

--- a/src/language-service.ts
+++ b/src/language-service.ts
@@ -463,11 +463,17 @@ export class TwindLanguageService implements TemplateLanguageService {
 
       if (selfRef) {
         matched.unshift(
-          Object.assign(Object.defineProperties({}, Object.getOwnPropertyDescriptors(selfRef)), {
-            value: '&',
-            raw: '&',
-            label: '&',
-          }),
+          Object.assign(
+            Object.defineProperties(
+              Object.assign({}, selfRef),
+              Object.getOwnPropertyDescriptors(selfRef),
+            ),
+            {
+              value: '&',
+              raw: '&',
+              label: '&',
+            },
+          ),
         )
       }
     }

--- a/src/load.ts
+++ b/src/load.ts
@@ -52,7 +52,7 @@ export const loadFile = <T>(file: string, cwd = process.cwd()): T => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require(moduleId) as T
   } catch (error) {
-    console.error(`Failed to load ${moduleId}: ${error.stack}`)
+    console.error(`Failed to load ${moduleId}: ${(error as Error).stack}`)
     return {} as T
   }
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -20,7 +20,8 @@ export function watch(
 
     return () => watcher.close()
   } catch (error) {
-    if (['ERR_FEATURE_UNAVAILABLE_ON_PLATFORM', 'ENOENT'].includes(error.code)) {
+    const errno = error as NodeJS.ErrnoException
+    if (errno.code && ['ERR_FEATURE_UNAVAILABLE_ON_PLATFORM', 'ENOENT'].includes(errno.code)) {
       return () => {
         /* no-op*/
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,10 +1366,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
+  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
 
 uri-js@^4.2.2:
   version "4.4.0"


### PR DESCRIPTION
Updates the plugin to work with Typescript 5. Most likely not backwards compatible with Typescript 4, I have not tried it.
The biggest change is the consolidation of `tsserverlibrary` and `typescript` libraries, and the removal of project wide `resolveModuleNames` (they are deprecated anyway). It now relies on the language server host to resolve the twind DTS file.

Typescript 5 is stricter, so some parts of the code had to be updated with proper typing.

Solves https://github.com/tw-in-js/typescript-plugin/issues/21, https://github.com/tw-in-js/vscode-twind-intellisense/issues/24, https://github.com/tw-in-js/vscode-twind-intellisense/issues/22, https://github.com/tw-in-js/vscode-twind-intellisense/issues/23

I read that you plan to rework this plugin to use your new intellisense package, but until that is done this should suffice.
You'll probably want to publish the current plugin as a v4 version, but that's entirely up to you!